### PR TITLE
version-locking ubuntu to trusty in dockerfile for coordinator container

### DIFF
--- a/cloud-formation/coordinatorContainer/Dockerfile
+++ b/cloud-formation/coordinatorContainer/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu
+# Version-locking to trusty to avoid JDK7 EOL issues.
+# Tags found here: https://hub.docker.com/r/library/ubuntu/tags
+FROM ubuntu:trusty
 
 # Update packages
 RUN apt-get update


### PR DESCRIPTION
Related Issue found here:
https://github.com/awslabs/dynamodb-cross-region-library/issues/23

Alternatively, AWS should consider upgrading to java 8 instead.
