### PR TITLE
Added missing permissions to cfn template

### DIFF
--- a/cloud-formation/dynamodb-replication-coordinator.coffee
+++ b/cloud-formation/dynamodb-replication-coordinator.coffee
@@ -223,6 +223,7 @@ Resources =
                 "cloudformation:DescribeStacks",
                 "cloudformation:DescribeStackEvents",
                 "cloudformation:DescribeStackResource",
+		"cloudformation:ListStackResources",
                 "cloudformation:CancelUpdateStack",
                 #TODO: We should limit action(s) needed to only relevant actions
                 "ec2:*",


### PR DESCRIPTION
The action cloudformation:ListStackResources has been added to the resource DynamoDBReplicationCoordinatorPolicy.
This action has been added to the 'official' template used when deploying from the aws console.
Without this line, the Elastic Beanstalk's environment will fail to update, and it's health will be set to red.
See issues #21 
