### PR TITLE
Add Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM openjdk:9-jre
+COPY target/*.jar /home/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This step sets up a replication process that continuously consumes DynamoDB stre
 		```
 			./build-with-docker.sh
 		```
+		* if you want to push this to your own docker repo for use on non local machines you will have to tag the image generated and push to a repo you control *
 
 2. This produces the target jar in the target/ directory, to start the replication process:
 	* with Java
@@ -49,7 +50,6 @@ This step sets up a replication process that continuously consumes DynamoDB stre
 		```
 	* with Docker 
 		```
-			docker build -t awslabs/dynamodb-cross-region-replication:1.1.0
 			docker run --rm -ti awslabs/dynamodb-cross-region-replication:1.1.0 "java" "-jar" "/home/dynamodb-cross-region-replication-1.1.0.jar" --sourceEndpoint YOUR_ENDPOINT --sourceTable YOUR_TABLE --destinationEndpoint YOUR_ENDPOINT --destinationTable YOUR_TABLE
 		```
 

--- a/README.md
+++ b/README.md
@@ -31,16 +31,27 @@ This step sets up a replication process that continuously consumes DynamoDB stre
 0. Enable DynamoDB Streams on your source table with StreamViewType set to "New and old images". For more information on how to do this, please refer to our [offical DynamoDB Streams documentation.](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html)
 
 1. Build the library:
+	* with Maven:
 
-```
-    mvn install
-```
+		```
+			mvn install
+		```
+	* with Docker
+		```
+			./build-with-docker.sh
+		```
 
 2. This produces the target jar in the target/ directory, to start the replication process:
+	* with Java
 
-```
-    java -jar dynamodb-cross-region-replication-<current_version>.jar --sourceEndpoint <source_dynamodb_endpoint> --sourceTable <source_table_name> --destinationEndpoint <destination_dynamodb_endpoint> --destinationTable <destination_table_name>
-```
+		```
+			java -jar dynamodb-cross-region-replication-<current_version>.jar --sourceEndpoint <source_dynamodb_endpoint> --sourceTable <source_table_name> --destinationEndpoint <destination_dynamodb_endpoint> --destinationTable <destination_table_name>
+		```
+	* with Docker 
+		```
+			docker build -t awslabs/dynamodb-cross-region-replication:1.1.0
+			docker run --rm -ti awslabs/dynamodb-cross-region-replication:1.1.0 "java" "-jar" "/home/dynamodb-cross-region-replication-1.1.0.jar" --sourceEndpoint YOUR_ENDPOINT --sourceTable YOUR_TABLE --destinationEndpoint YOUR_ENDPOINT --destinationTable YOUR_TABLE
+		```
 
 Use the `--help` option to view all available arguments to the connector executable jar. The connector process accomplishes a few things:
 * Sets up a [Kinesis Client Library (KCL)](https://github.com/awslabs/amazon-kinesis-client) worker to consume the DymamoDB Stream of the source table

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -1,0 +1,1 @@
+docker run -it --rm --name dynamodb-cross-region-library -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven maven:3.2-jdk-7 mvn clean install

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -1,2 +1,2 @@
 docker run -it --rm --name dynamodb-cross-region-library -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven maven:3.2-jdk-7 mvn clean install
-docker build -t awslabs/dynamodb-cross-region-replication:1.1.0
+docker build -t vungle/dynamodb-cross-region-replication:1.1.0 .

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -1,1 +1,2 @@
 docker run -it --rm --name dynamodb-cross-region-library -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven maven:3.2-jdk-7 mvn clean install
+docker build -t awslabs/dynamodb-cross-region-replication:1.1.0


### PR DESCRIPTION
We would like to run the jar generated from a docker container in kubernetes to easily distribute the load and configure for multiple tables.