### PR TITLE
Convert AmazonCloudWatchAsync and AmazonDynamoDBAsync to Non-Static

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/streams/connectors/DynamoDBReplicationEmitter.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/streams/connectors/DynamoDBReplicationEmitter.java
@@ -89,11 +89,11 @@ public class DynamoDBReplicationEmitter implements IEmitter<Record> {
     /**
      * AmazonCloudWatch for emitting metrics.
      */
-    private static final AtomicReference<AmazonCloudWatchAsync> CLOUDWATCH = new AtomicReference<AmazonCloudWatchAsync>();
+    private final AmazonCloudWatchAsync cloudWatch;
     /**
      * Asynchronous DynamoDB client for writing to the DynamoDB table.
      */
-    private static final AtomicReference<AmazonDynamoDBAsync> DYNAMODB = new AtomicReference<AmazonDynamoDBAsync>();
+    private final AmazonDynamoDBAsync dynamodDb;
     /**
      * Maximum number of threads for the Async clients.
      */
@@ -193,15 +193,13 @@ public class DynamoDBReplicationEmitter implements IEmitter<Record> {
         this.endpoint = endpoint;
         this.region = region;
         this.tableName = tableName;
+        this.dynamodDb = dynamoDBAsync;
+        this.dynamodDb.setEndpoint(endpoint);
+        this.cloudWatch = cloudwatch;
+        if (this.cloudWatch != null) {
+            this.cloudWatch.setRegion(Regions.getCurrentRegion() == null ? Region.getRegion(Regions.US_EAST_1) : Regions.getCurrentRegion());
+        }
 
-        final boolean setDynamoDB = DYNAMODB.compareAndSet(null, dynamoDBAsync);
-        if (setDynamoDB && dynamoDBAsync != null) {
-            DYNAMODB.get().setEndpoint(endpoint);
-        }
-        final boolean setCloudWatch = CLOUDWATCH.compareAndSet(null, cloudwatch);
-        if (setCloudWatch && cloudwatch != null) {
-            CLOUDWATCH.get().setRegion(Regions.getCurrentRegion() == null ? Region.getRegion(Regions.US_EAST_1) : Regions.getCurrentRegion());
-        }
         skipErrors = false; // TODO make configurable
     }
 
@@ -385,7 +383,7 @@ public class DynamoDBReplicationEmitter implements IEmitter<Record> {
      *            The records that failed to write to DynamoDB
      */
     protected synchronized void emitCloudWatchMetrics(final List<Record> records, final List<Record> failures, final AtomicInteger retryCount) {
-        AmazonCloudWatchAsync cloudwatch = CLOUDWATCH.get();
+        AmazonCloudWatchAsync cloudwatch = this.cloudWatch;
         if (null == cloudwatch) {
             return;
         }
@@ -440,7 +438,7 @@ public class DynamoDBReplicationEmitter implements IEmitter<Record> {
         for (Record record : records) {
             log.error("Could not emit record: " + record);
         }
-        final AmazonCloudWatchAsync cloudwatch = CLOUDWATCH.get();
+        final AmazonCloudWatchAsync cloudwatch = this.cloudWatch;
         if (null != cloudwatch) {
             final double failed = records.size();
             final MetricDatum recordsProcessedFailedDatum = new MetricDatum().withMetricName(RECORDS_FAILED).withValue(failed).withUnit(StandardUnit.Count)
@@ -481,7 +479,7 @@ public class DynamoDBReplicationEmitter implements IEmitter<Record> {
      * @return the dynamodb
      */
     public AmazonDynamoDBAsync getDynamodb() {
-        return DYNAMODB.get();
+        return dynamodDb;
     }
 
     /**


### PR DESCRIPTION
Summary: Convert AmazonCloudWatchAsync and AmazonDynamoDBAsync references from static to non-static to allow library to be used against multiple instances simultaneously. 

Details: In our case, we are leveraging this library to implement N-way replication of DynamoDb tables from within a single application. These static references lock all emitter instances to a particular AWS region (whichever is established first). Converting from static to non-static addresses our concerns. Further, in our analysis this change does not have any negative impact on the non-library use case since only a single emitter is instantiated and therefore a single instance of AmazonCloudWatchAsync and AmazonDynamoDBAsync remain.