### PR TITLE
Update google.guava dependency to fix the github dependabot alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <amazon.kinesis-client-library.version>1.7.5</amazon.kinesis-client-library.version>
         <amazon.kinesis-connectors.version>1.3.0</amazon.kinesis-connectors.version>
         <dynamodb-streams-kinesis-adapter.version>1.2.1</dynamodb-streams-kinesis-adapter.version>
-        <guava.version>18.0</guava.version>
+        <guava.version>29.0-jre</guava.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <junit.version>4.12</junit.version>
         <easymock.version>3.2</easymock.version>


### PR DESCRIPTION
*Issue #, if available:*
Fix the Dependabot alert for google guava. 

*Description of changes:*
change guava.version from 18.0 to 29.0-jre

Tested using:

> mvn clean install

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
